### PR TITLE
CA: Try waiting for MySQL daemon as long as it takes

### DIFF
--- a/tasks/ca.yml
+++ b/tasks/ca.yml
@@ -1,5 +1,5 @@
 name: CA
-entrypoint: [sh, -c, "mysql_install_db --user=root && mysqld_safe --max_allowed_packet=512M & /opt/openstates/openstates/openstates/ca/download.sh && ./pupa-scrape.sh ca bills"]
+entrypoint: [sh, -c, "mysql_install_db --user=root && mkdir /run/mysqld && mysqld --user root --datadir=/opt/openstates/openstates/data --max_allowed_packet=512M & /opt/openstates/openstates/openstates/ca/download.sh && ./pupa-scrape.sh ca bills"]
 cpu: 512
 memory_soft: 128
 memory: 4096

--- a/tasks/ca.yml
+++ b/tasks/ca.yml
@@ -1,5 +1,5 @@
 name: CA
-entrypoint: [sh, -c, "mysql_install_db --user=mysql && mysqld_safe --max_allowed_packet=512M & sleep 10 && /opt/openstates/venv-pupa/bin/python /opt/openstates/openstates/openstates/ca/download.py && ./pupa-scrape.sh ca bills"]
+entrypoint: [sh, -c, "mysql_install_db --user=root && mysqld_safe --max_allowed_packet=512M & /opt/openstates/openstates/openstates/ca/download.sh && ./pupa-scrape.sh ca bills"]
 cpu: 512
 memory_soft: 128
 memory: 4096


### PR DESCRIPTION
This is my best guess for now, and also brings the task definition closer to the (known-to-be-working) Docker Compose `ca-download` service. Not completely sure that the MySQL database user needs to be changed to `root`, but that would parallel the username that the `ca/download.sh` file tries to use to check for a database connection.

Thoughts on this, @jamesturk?

cc https://github.com/openstates/openstates/blob/master/docker-compose.yml#L40
cc https://github.com/openstates/openstates/blob/master/openstates/ca/download.sh