### PR TITLE
Propose more frequent early session scrapes for AL, AR, DE, FL, GA, MT

### DIFF
--- a/tasks/al.yml
+++ b/tasks/al.yml
@@ -4,7 +4,8 @@ AL-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 360
   next_tasks:
     - AL-text

--- a/tasks/ar.yml
+++ b/tasks/ar.yml
@@ -4,7 +4,8 @@ AR-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 6 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 6 * * ?
   timeout_minutes: 360
   next_tasks:
     - AR-text

--- a/tasks/de.yml
+++ b/tasks/de.yml
@@ -4,7 +4,8 @@ DE-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 5 * * ?
   memory: 1024
   timeout_minutes: 360
   next_tasks:

--- a/tasks/fl.yml
+++ b/tasks/fl.yml
@@ -4,7 +4,8 @@ FL-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 360
   next_tasks:
     - FL-text

--- a/tasks/ga.yml
+++ b/tasks/ga.yml
@@ -4,7 +4,8 @@ GA-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 480
   next_tasks:
     - GA-text

--- a/tasks/mt.yml
+++ b/tasks/mt.yml
@@ -4,7 +4,8 @@ MT-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - MT-text


### PR DESCRIPTION
What do you think about doing more frequent scrape runs as long as the scrape jobs execute quickly? My motivation was looking at MT, which had 29 bills in OS when I checked this afternoon, even though the source has 79. It seems like early in the session the smaller absolute deltas make the data look less valuable because they are high relative deltas.

My understanding is that scrape schedule is primarily limited by sensitivity of source websites to receiving too many requests. I'm assuming a strong correlation between execution time and number of requests. So would an ideal system basically scrape as often as it could do so, as long as it stays within a total daily request budget? 

I know there isn't a simple way to tie that into a feedback loop given how tasks are set up, but how about this protocol:

* Check how long new session scrape jobs are executing
* Any that are under 10 minutes, change definition to every 2 hours. Under 30 minutes, change to every 6 hours. (just guesses at these numbers).
* Keep the "normal" schedule commented in the task def so it's easy to restore.
* Check scrape job execution times again every week to adjust again, push a PR with the adjusted task defs.

I just checked the job execution times for the first 7 or so states that are ingesting prefiles and included task adjustments in this PR if the job was under 10 min.

Counterpoint: if a 1000+ bill introduction event occurs in one day, then this could cause the request budget to be overloaded quickly. So either monitoring would be needed (once a week not sufficient) or more conservative rules than what I proposed above could be followed.