### PR TITLE
IA: start ingesting 2021 prefiled bill requests

### DIFF
--- a/tasks/ia.yml
+++ b/tasks/ia.yml
@@ -1,6 +1,6 @@
 IA-scrape:
   image: openstates/scrapers
-  entrypoint: "poetry run os-update ia bills votes"
+  entrypoint: "poetry run os-update ia bills prefiles=True"
   enabled: true
   environment: scrapers
   triggers:


### PR DESCRIPTION
Looks like task definition never got changed to make use of Tim's work supporting ingestion of prefiled bill requests as proposed bills.