### PR TITLE
More frequent scrape schedule for tasks that are running quickly

### DIFF
--- a/tasks/az.yml
+++ b/tasks/az.yml
@@ -4,7 +4,8 @@ AZ-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - AZ-text

--- a/tasks/co.yml
+++ b/tasks/co.yml
@@ -4,7 +4,8 @@ CO-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - CO-text

--- a/tasks/ct.yml
+++ b/tasks/ct.yml
@@ -4,7 +4,8 @@ CT-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */6 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 360
   next_tasks:
     - CT-text

--- a/tasks/dc.yml
+++ b/tasks/dc.yml
@@ -4,7 +4,8 @@ DC-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 360
   next_tasks:
     - DC-text

--- a/tasks/ia.yml
+++ b/tasks/ia.yml
@@ -4,7 +4,8 @@ IA-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 6 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 6 * * ?
   timeout_minutes: 360
   next_tasks:
     - IA-text

--- a/tasks/id.yml
+++ b/tasks/id.yml
@@ -4,7 +4,8 @@ ID-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - ID-text

--- a/tasks/in.yml
+++ b/tasks/in.yml
@@ -4,7 +4,7 @@ IN-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 */2 * * ?
+    - cron: 0 */6 * * ?
 #    - cron: 0 6 * * ?
   timeout_minutes: 360
   next_tasks:

--- a/tasks/ks.yml
+++ b/tasks/ks.yml
@@ -4,7 +4,8 @@ KS-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - KS-text

--- a/tasks/ky.yml
+++ b/tasks/ky.yml
@@ -4,7 +4,8 @@ KY-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 6 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 6 * * ?
   timeout_minutes: 360
   next_tasks:
     - KY-text

--- a/tasks/ma.yml
+++ b/tasks/ma.yml
@@ -4,7 +4,8 @@ MA-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */6 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 2160  # 36 hours :(
   next_tasks:
     - MA-text

--- a/tasks/md.yml
+++ b/tasks/md.yml
@@ -4,7 +4,8 @@ MD-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 4 * * ?
+    - cron: 0 */6 * * ?
+#    - cron: 0 4 * * ?
   timeout_minutes: 360
   next_tasks:
     - MD-text

--- a/tasks/mn.yml
+++ b/tasks/mn.yml
@@ -4,7 +4,8 @@ MN-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - MN-text

--- a/tasks/ms.yml
+++ b/tasks/ms.yml
@@ -4,7 +4,8 @@ MS-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 6 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 6 * * ?
   timeout_minutes: 360
   next_tasks:
     - MS-text

--- a/tasks/nd.yml
+++ b/tasks/nd.yml
@@ -4,7 +4,8 @@ ND-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - ND-text

--- a/tasks/ne.yml
+++ b/tasks/ne.yml
@@ -4,7 +4,8 @@ NE-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - NE-text

--- a/tasks/nh.yml
+++ b/tasks/nh.yml
@@ -4,7 +4,8 @@ NH-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 360
   next_tasks:
     - NH-text

--- a/tasks/nm.yml
+++ b/tasks/nm.yml
@@ -4,7 +4,8 @@ NM-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 7 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 7 * * ?
   timeout_minutes: 360
   next_tasks:
     - NM-text

--- a/tasks/oh.yml
+++ b/tasks/oh.yml
@@ -4,7 +4,8 @@ OH-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 360
   next_tasks:
     - OH-text

--- a/tasks/pa.yml
+++ b/tasks/pa.yml
@@ -5,7 +5,8 @@ PA-scrape:
   memory: 1024
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */6 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 1080 # 18 hours to be safe :(
   next_tasks:
     - PA-text

--- a/tasks/pr.yml
+++ b/tasks/pr.yml
@@ -4,7 +4,8 @@ PR-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 4 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 4 * * ?
   timeout_minutes: 360
   next_tasks:
     - PR-text

--- a/tasks/ri.yml
+++ b/tasks/ri.yml
@@ -4,7 +4,8 @@ RI-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 360
   next_tasks:
     - RI-text

--- a/tasks/sc.yml
+++ b/tasks/sc.yml
@@ -4,7 +4,8 @@ SC-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 4 * * ?
+    - cron: 0 */6 * * ?
+#    - cron: 0 4 * * ?
   timeout_minutes: 1200
   next_tasks:
     - SC-text

--- a/tasks/ut.yml
+++ b/tasks/ut.yml
@@ -4,7 +4,8 @@ UT-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 8 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 8 * * ?
   timeout_minutes: 360
   next_tasks:
     - UT-text

--- a/tasks/vt.yml
+++ b/tasks/vt.yml
@@ -4,7 +4,8 @@ VT-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 5 * * ?
+    - cron: 0 */6 * * ?
+#    - cron: 0 5 * * ?
   timeout_minutes: 480
   next_tasks:
     - VT-text

--- a/tasks/wi.yml
+++ b/tasks/wi.yml
@@ -4,7 +4,8 @@ WI-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 6 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 6 * * ?
   timeout_minutes: 360
   next_tasks:
     - WI-text

--- a/tasks/wy.yml
+++ b/tasks/wy.yml
@@ -4,7 +4,8 @@ WY-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 8 * * ?
+    - cron: 0 */2 * * ?
+#    - cron: 0 8 * * ?
   timeout_minutes: 360
   next_tasks:
     - WY-text


### PR DESCRIPTION
Suggesting more frequent scrape schedules for additional states. Looked through bobsled timings and these seemed to be jobs that could run more frequently. But you have the experience with these states, so feel free to back any of these off as appropriate.