### PR TITLE
MA: add unlimited bill scrape three times a week to catch missing bills

### DIFF
--- a/tasks/ma.yml
+++ b/tasks/ma.yml
@@ -10,6 +10,17 @@ MA-scrape:
   next_tasks:
     - MA-text
 
+MA-scrape-full:
+  image: openstates/scrapers
+  entrypoint: "poetry run os-update ma bills"
+  enabled: true
+  environment: scrapers
+  triggers:
+    - cron: 0 5 * * tue,fri,sun
+  timeout_minutes: 2160  # 36 hours :(
+  next_tasks:
+    - MA-text
+
 MA-text:
   image: openstates/text-extraction
   entrypoint: "poetry run ./text_extract.py update ma"


### PR DESCRIPTION
Looks like we're missing a lot of MA bills, guessing the page_limit=20 scraper arg is the culprit. Tough to calibrate for ephemeral bills, but 300-600 I think. I'm guessing the page_limit=20 parameter is the culprit. Looking at how the scraper sorts bills by "latest" it looks like there are a lot of high-numbered missing bills (eg HD 4084) actually being listed pretty late in the MA pagination (https://malegislature.gov/Bills/Search?SearchTerms=&Page=257&Refinements%5Blawsgeneralcourt%5D=3139326e64202843757272656e7429).