### PR TITLE
WI: point scraper back at 2021 session

### DIFF
--- a/tasks/wi.yml
+++ b/tasks/wi.yml
@@ -1,6 +1,6 @@
 WI-scrape:
   image: openstates/scrapers
-  entrypoint: "poetry run os-update wi bills"
+  entrypoint: "poetry run os-update wi bills session=2021"
   enabled: true
   environment: scrapers
   triggers:


### PR DESCRIPTION
It appears that the special session is over, and now bills are missing from the 2021 session (AB 100 for example).