### PR TITLE
MA: attempt to reduce full-scrape failures by splitting into upper/lower

### DIFF
--- a/tasks/ma.yml
+++ b/tasks/ma.yml
@@ -10,13 +10,24 @@ MA-scrape:
   next_tasks:
     - MA-text
 
-MA-scrape-full:
+MA-scrape-full-lower:
   image: openstates/scrapers
-  entrypoint: "poetry run os-update ma bills"
+  entrypoint: "poetry run os-update ma bills chamber=lower"
   enabled: true
   environment: scrapers
   triggers:
     - cron: 0 5 * * 2,4,6 # tue,fri,sun
+  timeout_minutes: 2160  # 36 hours :(
+  next_tasks:
+    - MA-text
+
+MA-scrape-full-upper:
+  image: openstates/scrapers
+  entrypoint: "poetry run os-update ma bills chamber=upper"
+  enabled: true
+  environment: scrapers
+  triggers:
+    - cron: 0 5 * * 1,3,5 # mon,wed,thurs
   timeout_minutes: 2160  # 36 hours :(
   next_tasks:
     - MA-text


### PR DESCRIPTION
Attempting to mitigate the failures that continue to plague at least half of the MA full-scrape runs. The failures continue to be on the [KeyError caused by some kind of unexpected response when the scraper switches to the second chamber](https://open-states.slack.com/archives/CQ1CUSRFG/p1619760431052900). It occurred to me that a quick mitigation might be to simply split the job up so that the scrape logic never switches chambers. 

This change sets up two full scrape jobs: one that scrapes the lower chamber on tues/fri/sun and the other scrapes the upper chamber on mon/wed/thurs. 