### PR TITLE
Add scrapes for AR regular and TX 1st special

### DIFF
--- a/tasks/ar.yml
+++ b/tasks/ar.yml
@@ -10,6 +10,18 @@ AR-scrape:
   next_tasks:
     - AR-text
 
+AR-scrape-regular:
+  image: openstates/scrapers
+  entrypoint: "poetry run os-update ar bills session=2021"
+  enabled: true
+  environment: scrapers
+  triggers:
+    - cron: 0 */6 * * ?
+#    - cron: 0 6 * * ?
+  timeout_minutes: 360
+  next_tasks:
+    - AR-text
+
 AR-text:
   image: openstates/core
   entrypoint: "poetry run os-text-extract update ar"

--- a/tasks/tx.yml
+++ b/tasks/tx.yml
@@ -11,6 +11,15 @@ TX-scrape:
   next_tasks:
     - TX-text
 
+TX-scrape-1st-special:
+  image: openstates/scrapers
+  entrypoint: "poetry run os-update tx bills session=871"
+  enabled: true
+  environment: scrapers
+  timeout_minutes: 480
+  next_tasks:
+    - TX-text
+
 TX-text:
   image: openstates/core
   entrypoint: "poetry run os-text-extract update tx"


### PR DESCRIPTION
Missing a few bills from each of those sessions, so adds support to scrape those. Both could probably be manually triggered but trying this out.