### PR TITLE
TX: add regular session

### DIFF
--- a/tasks/tx.yml
+++ b/tasks/tx.yml
@@ -20,6 +20,15 @@ TX-scrape-1st-special:
   next_tasks:
     - TX-text
 
+TX-scrape-regular:
+  image: openstates/scrapers
+  entrypoint: "poetry run os-update tx bills session=87"
+  enabled: true
+  environment: scrapers
+  timeout_minutes: 480
+  next_tasks:
+    - TX-text
+
 TX-text:
   image: openstates/core
   entrypoint: "poetry run os-text-extract update tx"


### PR DESCRIPTION
Leaves option to run scraper on TX 2021 regular session for bills they keep adding after the fact.