### PR TITLE
TX: increase timeout for regular 2021

### DIFF
--- a/tasks/tx.yml
+++ b/tasks/tx.yml
@@ -25,7 +25,7 @@ TX-scrape-regular:
   entrypoint: "poetry run os-update tx bills session=87"
   enabled: true
   environment: scrapers
-  timeout_minutes: 480
+  timeout_minutes: 1200
   next_tasks:
     - TX-text
 


### PR DESCRIPTION
Scraper keeps timing out so increased to see if it runs successfully @jamesturk 