### PR TITLE
change NH scrape timing to fix scraping limitations

### DIFF
--- a/tasks/nh.yml
+++ b/tasks/nh.yml
@@ -4,8 +4,12 @@ NH-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 */2 * * ?
+#    - cron: 0 */2 * * ?
 #    - cron: 0 5 * * ?
+#   http://www.gencourt.state.nh.us/scrap/scrape.html
+#   NH is limiting scraping to during the night only
+#   2 a.m. - 11 a.m. UTC should be 9 p.m. - 6 a.m. EDT
+     - cron: 0 2-11/2 * * ?
   timeout_minutes: 360
   next_tasks:
     - NH-text


### PR DESCRIPTION
NH is blocking scraping during the day due to "abuse". This schedule should stop our daily failures.

Signed-off-by: John Seekins <john@civiceagle.com>