### PR TITLE
increase timeout for IL

### DIFF
--- a/tasks/il.yml
+++ b/tasks/il.yml
@@ -7,7 +7,7 @@ IL-scrape:
   triggers:
     - cron: 0 */6 * * ?
 #    - cron: 0 6 * * ?
-  timeout_minutes: 900 # regularly 12 hours, 15 to be safe
+  timeout_minutes: 1080 # regularly 12 hours, 18 to be safe
   next_tasks:
     - IL-text
 


### PR DESCRIPTION
Signed-off-by: John Seekins <john@civiceagle.com>

IL is timing out with 15 hours. Let's bump to 18 to give it more space.