### PR TITLE
US: update us-text entrypoint param to 'us'

### DIFF
--- a/tasks/us.yml
+++ b/tasks/us.yml
@@ -11,7 +11,7 @@ US-scrape:
 
 US-text:
   image: openstates/core
-  entrypoint: "poetry run os-text-extract update usa"
+  entrypoint: "poetry run os-text-extract update us"
   enabled: true
   environment: scrapers
 


### PR DESCRIPTION
Updates param in US-text task definition entrypoint from `usa` to `us`.