### PR TITLE
SC: past session bill scrape jobs add

### DIFF
--- a/tasks/sc.yml
+++ b/tasks/sc.yml
@@ -10,6 +10,24 @@ SC-scrape:
   next_tasks:
     - SC-text
 
+SC-2021-2022-scrape:
+  image: openstates/scrapers
+  entrypoint: "poetry run os-update sc bills session=2021-2022"
+  enabled: true
+  environment: scrapers
+  triggers:
+    - cron: 0 19 * * 2
+  timeout_minutes: 1200
+
+SC-2019-2020-scrape:
+  image: openstates/scrapers
+  entrypoint: "poetry run os-update sc bills session=2019-2020"
+  enabled: true
+  environment: scrapers
+  triggers:
+    - cron: 0 23 * * 2
+  timeout_minutes: 1200
+
 SC-text:
   image: openstates/core
   entrypoint: "poetry run os-text-extract update sc"

--- a/tasks/sc.yml
+++ b/tasks/sc.yml
@@ -16,7 +16,7 @@ SC-2021-2022-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 19 * * 2
+    - cron: 0 18 * * 3
   timeout_minutes: 1200
 
 SC-2019-2020-scrape:
@@ -25,7 +25,7 @@ SC-2019-2020-scrape:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 23 * * 2
+    - cron: 0 22 * * 3
   timeout_minutes: 1200
 
 SC-text:


### PR DESCRIPTION
Adds task definitions to scrape bills for two past legislative sessions: 2019-2020 and 2021-2022. They are scheduled to occur weekly, but this may be removed shortly after the data from the initial runs have been successfully imported.

See [related pull request](https://github.com/openstates/openstates-scrapers/pull/4654) on openstates-scrapers repo.

The `entrypoint` syntax for specifying the session by its identifier was tested locally on the command line, and it successfully executes a scrape for the specified session regardless of whether or not the session is marked as 'active'.