### PR TITLE
Temporarily disable ar bills, mo bills + events

### DIFF
--- a/tasks/ar.yml
+++ b/tasks/ar.yml
@@ -1,20 +1,25 @@
-AR-scrape:
-  image: openstates/scrapers
-  entrypoint: "poetry run os-update ar bills"
-  enabled: true
-  environment: scrapers
-  triggers:
-#    - cron: 20 */4 * * ?
-    - cron: 0 6 * * ?
-  timeout_minutes: 360
-  next_tasks:
-    - AR-text
+# Commenting out AR-scrape as it needs to be rewritten and AR is out of session
+#AR-scrape:
+#  image: openstates/scrapers
+#  entrypoint: "poetry run os-update ar bills"
+#  enabled: true
+#  environment: scrapers
+#  triggers:
+##    - cron: 20 */4 * * ?
+#    - cron: 0 6 * * ?
+#  timeout_minutes: 360
+#  next_tasks:
+#    - AR-text
 
 AR-text:
   image: openstates/core
   entrypoint: "poetry run os-text-extract update ar"
   enabled: true
   environment: scrapers
+  # TODO: Remove `triggers` once AR-scrape has been commented back in
+  #  because AR-text is normally triggered by AR-scrape's `next_tasks`
+  triggers:
+    - cron: 0 6 * * ?
 
 AR-events:
   image: openstates/scrapers

--- a/tasks/mo.yml
+++ b/tasks/mo.yml
@@ -1,14 +1,16 @@
-MO-scrape:
-  image: openstates/scrapers
-  entrypoint: "poetry run os-update mo bills"
-  enabled: true
-  environment: scrapers
-  triggers:
-#    - cron: 0 */6 * * ?
-    - cron: 40 6 * * ?
-  timeout_minutes: 360
-  next_tasks:
-    - MO-text
+# Commenting out MO-scrape & MO-events as they need to be rewritten
+#  and MO is out of session
+#MO-scrape:
+#  image: openstates/scrapers
+#  entrypoint: "poetry run os-update mo bills"
+#  enabled: true
+#  environment: scrapers
+#  triggers:
+##    - cron: 0 */6 * * ?
+#    - cron: 40 6 * * ?
+#  timeout_minutes: 360
+#  next_tasks:
+#    - MO-text
 
 MO-text:
   image: openstates/core
@@ -16,11 +18,11 @@ MO-text:
   enabled: true
   environment: scrapers
 
-MO-events:
-  image: openstates/scrapers
-  entrypoint: "poetry run os-update mo events"
-  enabled: true
-  environment: scrapers
-  triggers:
-    - cron: 40 6 * * ?
-  timeout_minutes: 60
+#MO-events:
+#  image: openstates/scrapers
+#  entrypoint: "poetry run os-update mo events"
+#  enabled: true
+#  environment: scrapers
+#  triggers:
+#    - cron: 40 6 * * ?
+#  timeout_minutes: 60


### PR DESCRIPTION
Comments out AR-scrape, MO-scrape, and MO-events tasks.
- MO scraper is currently being rewritten for XML
- both jurisdictions out of session
- all three scrapers have been failing for a while and require fairly involved fixes
- *this is also happening within the larger context of testing the viability of Airflow for future scraper task management*