### PR TITLE
Increase event scrape frequency to 4x/day

### DIFF
--- a/tasks/il.yml
+++ b/tasks/il.yml
@@ -23,5 +23,5 @@ IL-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 25 5 * * ?
+    - cron: 25 */6 * * ?
   timeout_minutes: 60

--- a/tasks/ma.yml
+++ b/tasks/ma.yml
@@ -44,5 +44,5 @@ MA-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 15 6 * * ?
+    - cron: 15 */6 * * ?
   timeout_minutes: 60

--- a/tasks/me.yml
+++ b/tasks/me.yml
@@ -22,5 +22,5 @@ ME-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 20 6 * * ?
+    - cron: 20 */6 * * ?
   timeout_minutes: 60

--- a/tasks/mn.yml
+++ b/tasks/mn.yml
@@ -17,7 +17,7 @@ MN-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 20 8,17 * * ?
+    - cron: 20 */6 * * ?
   timeout_minutes: 60
 
 MN-text:

--- a/tasks/nd.yml
+++ b/tasks/nd.yml
@@ -22,5 +22,5 @@ ND-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 10 9 * * ?
+    - cron: 10 */6 * * ?
   timeout_minutes: 60

--- a/tasks/nv.yml
+++ b/tasks/nv.yml
@@ -22,5 +22,5 @@ NV-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 10 * * ?
+    - cron: 0 */6 * * ?
   timeout_minutes: 60

--- a/tasks/ny.yml
+++ b/tasks/ny.yml
@@ -23,5 +23,5 @@ NY-events:
   environment: scrapers
   memory: 1024
   triggers:
-    - cron: 25 3 * * ?
+    - cron: 25 */6 * * ?
   timeout_minutes: 60

--- a/tasks/oh.yml
+++ b/tasks/oh.yml
@@ -22,5 +22,5 @@ OH-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 12 * * ?
+    - cron: 0 */6 * * ?
   timeout_minutes: 60

--- a/tasks/ok.yml
+++ b/tasks/ok.yml
@@ -22,5 +22,5 @@ OK-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 10 12 * * ?
+    - cron: 10 */6 * * ?
   timeout_minutes: 60

--- a/tasks/pa.yml
+++ b/tasks/pa.yml
@@ -23,5 +23,5 @@ PA-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 20 12 * * ?
+    - cron: 20 */6 * * ?
   timeout_minutes: 60

--- a/tasks/sc.yml
+++ b/tasks/sc.yml
@@ -22,7 +22,7 @@ SC-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 40 12 * * ?
+    - cron: 40 */6 * * ?
   timeout_minutes: 60
 
 ## Can be commented in to scrape past session bill data, when necessary

--- a/tasks/tn.yml
+++ b/tasks/tn.yml
@@ -23,5 +23,5 @@ TN-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 0 13 * * ?
+    - cron: 0 */6 * * ?
   timeout_minutes: 60

--- a/tasks/us.yml
+++ b/tasks/us.yml
@@ -21,5 +21,5 @@ US-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 50 1 * * ?
+    - cron: 50 */6 * * ?
   timeout_minutes: 60

--- a/tasks/vt.yml
+++ b/tasks/vt.yml
@@ -22,5 +22,5 @@ VT-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 10 13 * * ?
+    - cron: 10 */6 * * ?
   timeout_minutes: 60

--- a/tasks/wa.yml
+++ b/tasks/wa.yml
@@ -22,5 +22,5 @@ WA-events:
   enabled: true
   environment: scrapers
   triggers:
-    - cron: 50 2 * * ?
+    - cron: 50 */6 * * ?
   timeout_minutes: 60


### PR DESCRIPTION
I checked all the event scrapers still running on Bobsled (except CA, which still uses the MySQL download source, so special case). 

They all run in less than 5 minutes, except for NV which is ~25 min. 

It seems like event calendars tend to be updated kinda last minute, so scraping more frequently may catch hearings that otherwise would come and go between scrapes. Since these scrapers run very quickly, it seems like no downside to run them more frequently.